### PR TITLE
fix: Return response from Lidarr API if it contains an error on Artists API

### DIFF
--- a/src/deemix.ts
+++ b/src/deemix.ts
@@ -344,6 +344,7 @@ async function getAritstByName(name: string) {
 }
 
 export async function getArtist(lidarr: any) {
+  if (lidarr["error"]) return lidarr;
   const artist = await getAritstByName(lidarr["artistname"]);
   if (typeof artist === "undefined") {
     return lidarr;


### PR DESCRIPTION
The search function allows using `lidarr:` followed by a GUID to search MB for artists and albums. Normal flow appears to be to search for an artist, and if that fails then search release groups, but the proxy isn't expecting the error and crashes out so Lidarr thinks the API is down.

This just adds a check on the response from Lidarr's API to see if there's an error on the model returned, and return before trying to process what are at that point undefined fields.

Closes #16